### PR TITLE
hypestv: add paravisor kmsg output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4269,7 +4269,6 @@ dependencies = [
  "clap_dyn_complete",
  "ctrlc",
  "diag_client",
- "env_logger",
  "fs-err",
  "futures",
  "futures-concurrency",
@@ -4281,6 +4280,7 @@ dependencies = [
  "socket2",
  "term",
  "thiserror 2.0.0",
+ "tracing-subscriber",
  "unicycle",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,6 +2975,7 @@ dependencies = [
  "futures-concurrency",
  "guid",
  "inspect",
+ "kmsg",
  "mesh",
  "pal_async",
  "parking_lot",

--- a/Guide/src/dev_guide/dev_tools/hypestv.md
+++ b/Guide/src/dev_guide/dev_tools/hypestv.md
@@ -17,14 +17,15 @@ will always be a Hyper-V specific tool.
 Currently, it can:
 
 * Change VM state (starting/stopping/resetting)
-* Enable serial port output
+* Enable serial port output to standard output, or input/output to another
+  terminal window
+* Enable paravisor log output to standard output or another terminal window
 * Inspect paravisor state
 
 In the future, it might be able to:
 
-* Enable paravisor and Hyper-V log output
-* Enable serial port input
-* Capture serial port output to another terminal window or file
+* Enable Hyper-V log output
+* Capture serial port output to a file
 * Inspect host state
 * Persistence workspaces (save/restore configured serial ports and logs)
 
@@ -52,6 +53,12 @@ tdxvm [off]> serial 1 term
 tdxvm [off]> serial 2 log
 ```
 
+You can also enable paravisor log output at any time:
+
+```
+tdxvm [off]> paravisor kmsg log
+```
+
 Start a VM with `start`. This is an asynchronous command: you can continue to
 type other commands at the prompt while the VM starts. You should see an output
 message when the VM finishes starting, as well as output about any configured
@@ -62,8 +69,8 @@ on the prompt may not be accurate until you type another command or press Enter.
 
 ```
 tdxvm [off]> start
-serial port 1 connected
-serial port 2 connected
+com1 connected
+com2 connected
 VM started
 tdxvm [off]>
 tdxvm [running]>
@@ -71,11 +78,10 @@ tdxvm [running]>
 
 At this point, the VM is running, including the paravisor (if one is
 configured). As in the OpenVMM interactive console, you can inspect paravisor
-state with the `inspect` or `x` command, passing `-p` to specify that you want
-to inspect paravisor state:
+state with the `inspect` or `x` command, but under the `paravisor`/`pv` command:
 
 ```
-tdxvm [running]> x -p
+tdxvm [running]> pv x
 {
     build_info: _,
     control_state: "started",
@@ -94,8 +100,8 @@ VM.
 
 ```
 tdxvm [running]> kill
-serial port 1 disconnected
-serial port 2 disconnected
+com1 disconnected
+com2 disconnected
 VM killed
 tdxvm [stopping]>
 tdxvm [off]>

--- a/hyperv/tools/hypestv/Cargo.toml
+++ b/hyperv/tools/hypestv/Cargo.toml
@@ -12,6 +12,7 @@ console_relay.workspace = true
 diag_client.workspace = true
 guid.workspace = true
 inspect.workspace = true
+kmsg.workspace = true
 mesh.workspace = true
 pal_async.workspace = true
 

--- a/hyperv/tools/hypestv/src/windows/completions.rs
+++ b/hyperv/tools/hypestv/src/windows/completions.rs
@@ -80,7 +80,7 @@ impl clap_dyn_complete::CustomCompleter for OpenvmmComplete {
         arg_id: &str,
     ) -> Vec<String> {
         match (subcommand_path, arg_id) {
-            (["hypestv", "inspect"], "element") => {
+            (["hypestv", "paravisor", "inspect"], "element") => {
                 let on_error = vec!["failed/to/connect".into()];
 
                 let (parent_path, to_complete) = (ctx.to_complete)
@@ -88,30 +88,11 @@ impl clap_dyn_complete::CustomCompleter for OpenvmmComplete {
                     .unwrap_or(("", ctx.to_complete));
 
                 let node = {
-                    let paravisor = {
-                        let raw_arg = ctx
-                            .matches
-                            .subcommand()
-                            .unwrap()
-                            .1
-                            .get_one::<String>("paravisor")
-                            .map(|x| x.as_str())
-                            .unwrap_or_default();
-                        raw_arg == "true"
-                    };
-
                     let r = self
                         .req
                         .call_failable(
                             super::Request::Inspect,
-                            (
-                                if paravisor {
-                                    super::InspectTarget::Paravisor
-                                } else {
-                                    super::InspectTarget::Host
-                                },
-                                parent_path.to_owned(),
-                            ),
+                            (super::InspectTarget::Paravisor, parent_path.to_owned()),
                         )
                         .await;
                     let Ok(node) = r else {

--- a/hyperv/tools/hypestv/src/windows/mod.rs
+++ b/hyperv/tools/hypestv/src/windows/mod.rs
@@ -56,11 +56,11 @@ pub(crate) enum InteractiveCommand {
 #[derive(Parser)]
 pub(crate) enum VmCommand {
     /// Start the VM.
-    Start {
-        /// Tell the paravisor to start the VM.
-        #[clap(short, long)]
-        paravisor: bool,
-    },
+    Start,
+
+    /// Paravisor commands.
+    #[clap(subcommand, visible_alias = "pv")]
+    Paravisor(ParavisorCommand),
 
     /// Power off the VM.
     Kill {
@@ -96,25 +96,21 @@ pub(crate) enum VmCommand {
         /// The serial output mode.
         mode: Option<SerialMode>,
     },
+}
 
-    /// Inspect host or paravisor state.
-    #[clap(visible_alias = "x")]
-    Inspect {
-        /// Enumerate state recursively.
-        #[clap(short, long)]
-        recursive: bool,
-        /// The recursive depth limit.
-        #[clap(short, long, requires("recursive"))]
-        limit: Option<usize>,
-        /// Send the inspect request to the paravisor running in the VM.
-        #[clap(short = 'p', short_alias = 'v', long)]
-        paravisor: bool,
-        /// Update the path with a new value.
-        #[clap(short, long, conflicts_with("recursive"))]
-        update: Option<String>,
-        /// The element path to inspect.
-        element: Option<String>,
-    },
+#[derive(Parser)]
+pub(crate) struct InspectArgs {
+    /// Enumerate state recursively.
+    #[clap(short, long)]
+    recursive: bool,
+    /// The recursive depth limit.
+    #[clap(short, long, requires("recursive"))]
+    limit: Option<usize>,
+    /// Update the path with a new value.
+    #[clap(short, long, conflicts_with("recursive"))]
+    update: Option<String>,
+    /// The element path to inspect.
+    element: Option<String>,
 }
 
 #[derive(ValueEnum, Copy, Clone)]
@@ -130,6 +126,34 @@ pub(crate) enum SerialMode {
 }
 
 impl Display for SerialMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad(self.to_possible_value().unwrap().get_name())
+    }
+}
+
+#[derive(Parser)]
+pub(crate) enum ParavisorCommand {
+    /// Tell the paravisor to start the VM.
+    Start,
+
+    /// Get or set the output mode for paravisor kmsg logs.
+    Kmsg { mode: Option<LogMode> },
+
+    #[clap(visible_alias = "x")]
+    Inspect(InspectArgs),
+}
+
+#[derive(ValueEnum, Copy, Clone)]
+pub enum LogMode {
+    /// The log output is disabled.
+    Off,
+    /// The log is written to standard output.
+    Log,
+    /// The log is written to a new terminal emulator window.
+    Term,
+}
+
+impl Display for LogMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.pad(self.to_possible_value().unwrap().get_name())
     }

--- a/hyperv/tools/hypestv/src/windows/mod.rs
+++ b/hyperv/tools/hypestv/src/windows/mod.rs
@@ -139,6 +139,7 @@ pub(crate) enum ParavisorCommand {
     /// Get or set the output mode for paravisor kmsg logs.
     Kmsg { mode: Option<LogMode> },
 
+    /// Inpsect paravisor state.
     #[clap(visible_alias = "x")]
     Inspect(InspectArgs),
 }

--- a/hyperv/tools/hypestv/src/windows/mod.rs
+++ b/hyperv/tools/hypestv/src/windows/mod.rs
@@ -167,7 +167,6 @@ pub(crate) enum Request {
 }
 
 pub(crate) enum InspectTarget {
-    Host,
     Paravisor,
 }
 

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -90,8 +90,11 @@ impl Vm {
         match cmd {
             VmCommand::Start { paravisor } => {
                 if paravisor {
-                    let diag = self.diag_client().await?;
-                    diag.start([], []).await.context("start failed")?;
+                    self.paravisor_diag
+                        .start([], [])
+                        .await
+                        .context("start failed")?;
+
                     writeln!(self.inner.printer.out(), "guest started within paravisor")?;
                 } else {
                     self.delay(move |inner| {
@@ -206,7 +209,6 @@ impl Vm {
                 if !paravisor {
                     anyhow::bail!("no host inspect yet");
                 }
-                let diag = self.diag_client().await?;
                 if let Some(update) = update {
                     let value = self
                         .paravisor_diag

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 pub struct Vm {
-    paravisor_diag: Option<DiagClient>,
+    paravisor_diag: DiagClient,
     inner: Arc<VmInner>,
     serial: Vec<Option<SerialTask>>,
 }
@@ -48,13 +48,13 @@ impl Vm {
     pub fn new(driver: DefaultDriver, name: String, printer: Printer) -> anyhow::Result<Self> {
         let id = diag_client::hyperv::vm_id_from_name(&name).context("failed to get vm id")?;
         let inner = Arc::new(VmInner {
-            driver,
+            driver: driver.clone(),
             printer,
             name,
             id,
         });
         Ok(Self {
-            paravisor_diag: None,
+            paravisor_diag: DiagClient::from_hyperv_id(driver, id),
             serial: (0..4).map(|_| None).collect(),
             inner,
         })
@@ -69,16 +69,6 @@ impl Vm {
         });
     }
 
-    async fn diag_client(&mut self) -> anyhow::Result<&mut DiagClient> {
-        if self.paravisor_diag.is_none() {
-            let diag = DiagClient::from_hyperv_id(self.inner.driver.clone(), self.inner.id)
-                .await
-                .context("failed to connect to paravisor")?;
-            self.paravisor_diag = Some(diag);
-        }
-        Ok(self.paravisor_diag.as_mut().unwrap())
-    }
-
     pub async fn handle_inspect(
         &mut self,
         target: InspectTarget,
@@ -89,8 +79,7 @@ impl Vm {
                 anyhow::bail!("host inspect not supported yet");
             }
             InspectTarget::Paravisor => {
-                self.diag_client()
-                    .await?
+                self.paravisor_diag
                     .inspect(path, Some(0), Some(Duration::from_secs(1)))
                     .await
             }
@@ -219,23 +208,22 @@ impl Vm {
                 }
                 let diag = self.diag_client().await?;
                 if let Some(update) = update {
-                    let value = diag
+                    let value = self
+                        .paravisor_diag
                         .update(element.unwrap_or_default(), update)
                         .await
                         .context("update failed")?;
 
                     println!("{:#}", value);
                 } else {
-                    let node = diag
+                    let node = self
+                        .paravisor_diag
                         .inspect(
                             element.unwrap_or_default(),
                             if recursive { limit } else { Some(0) },
                             Some(Duration::from_secs(1)),
                         )
                         .await
-                        .inspect_err(|_| {
-                            self.paravisor_diag = None;
-                        })
                         .context("inspect failed")?;
 
                     println!("{:#}", node);

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -7,13 +7,17 @@ use super::hyperv::hvc_output;
 use super::hyperv::run_hcsdiag;
 use super::hyperv::run_hvc;
 use super::rustyline_printer::Printer;
+use super::InspectArgs;
 use super::InspectTarget;
+use super::LogMode;
+use super::ParavisorCommand;
 use super::SerialMode;
 use super::VmCommand;
 use anyhow::Context as _;
 use diag_client::DiagClient;
 use futures::io::BufReader;
 use futures::AsyncBufReadExt;
+use futures::AsyncWriteExt;
 use futures::FutureExt;
 use futures::StreamExt;
 use futures_concurrency::future::Race;
@@ -26,9 +30,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 pub struct Vm {
-    paravisor_diag: DiagClient,
     inner: Arc<VmInner>,
     serial: Vec<Option<SerialTask>>,
+    pv_kmsg: Option<KmsgTask>,
 }
 
 struct SerialTask {
@@ -37,8 +41,15 @@ struct SerialTask {
     req: mesh::Sender<SerialRequest>,
 }
 
+struct KmsgTask {
+    mode: LogMode,
+    task: Task<()>,
+    req: mesh::Sender<SerialRequest>,
+}
+
 struct VmInner {
     driver: DefaultDriver,
+    paravisor_diag: DiagClient,
     name: String,
     id: Guid,
     printer: Printer,
@@ -49,14 +60,15 @@ impl Vm {
         let id = diag_client::hyperv::vm_id_from_name(&name).context("failed to get vm id")?;
         let inner = Arc::new(VmInner {
             driver: driver.clone(),
+            paravisor_diag: DiagClient::from_hyperv_id(driver, id),
             printer,
             name,
             id,
         });
         Ok(Self {
-            paravisor_diag: DiagClient::from_hyperv_id(driver, id),
             serial: (0..4).map(|_| None).collect(),
             inner,
+            pv_kmsg: None,
         })
     }
 
@@ -79,7 +91,8 @@ impl Vm {
                 anyhow::bail!("host inspect not supported yet");
             }
             InspectTarget::Paravisor => {
-                self.paravisor_diag
+                self.inner
+                    .paravisor_diag
                     .inspect(path, Some(0), Some(Duration::from_secs(1)))
                     .await
             }
@@ -88,22 +101,11 @@ impl Vm {
 
     pub async fn handle_command(&mut self, cmd: VmCommand) -> anyhow::Result<()> {
         match cmd {
-            VmCommand::Start { paravisor } => {
-                if paravisor {
-                    self.paravisor_diag
-                        .start([], [])
-                        .await
-                        .context("start failed")?;
-
-                    writeln!(self.inner.printer.out(), "guest started within paravisor")?;
-                } else {
-                    self.delay(move |inner| {
-                        run_hvc(|cmd| cmd.arg("start").arg(&inner.name))?;
-                        writeln!(inner.printer.out(), "VM started")?;
-                        Ok(())
-                    })
-                }
-            }
+            VmCommand::Start => self.delay(move |inner| {
+                run_hvc(|cmd| cmd.arg("start").arg(&inner.name))?;
+                writeln!(inner.printer.out(), "VM started")?;
+                Ok(())
+            }),
             VmCommand::Kill { force } => self.delay(move |inner| {
                 if force {
                     run_hcsdiag(|cmd| cmd.arg("kill").arg(inner.id.to_string()))?;
@@ -199,18 +201,65 @@ impl Vm {
                     }
                 }
             }
-            VmCommand::Inspect {
+            VmCommand::Paravisor(cmd) => self.handle_paravisor_command(cmd).await?,
+        }
+        Ok(())
+    }
+
+    async fn handle_paravisor_command(&mut self, cmd: ParavisorCommand) -> anyhow::Result<()> {
+        match cmd {
+            ParavisorCommand::Start => {
+                self.inner
+                    .paravisor_diag
+                    .start([], [])
+                    .await
+                    .context("start failed")?;
+
+                writeln!(self.inner.printer.out(), "guest started within paravisor")?;
+            }
+            ParavisorCommand::Kmsg { mode: None } => {
+                println!("{}", self.pv_kmsg.as_ref().map_or(LogMode::Off, |t| t.mode));
+            }
+            ParavisorCommand::Kmsg { mode: Some(mode) } => {
+                let target = match mode {
+                    LogMode::Off => {
+                        if let Some(task) = self.pv_kmsg.take() {
+                            drop(task.req);
+                            task.task.await;
+                        }
+                        None
+                    }
+                    LogMode::Log => Some(SerialTarget::Printer),
+                    LogMode::Term => Some(SerialTarget::Console(
+                        console_relay::Console::new(self.inner.driver.clone(), None)
+                            .context("failed to launch console")?,
+                    )),
+                };
+                if let Some(target) = target {
+                    if let Some(task) = &mut self.pv_kmsg {
+                        task.mode = mode;
+                        task.req.send(SerialRequest::NewTarget(target));
+                    } else {
+                        let (req, recv) = mesh::channel();
+                        let inner = self.inner.clone();
+                        let t = self.inner.driver.spawn("kmsg", async move {
+                            if let Err(err) = inner.handle_kmsg(recv, target).await {
+                                writeln!(inner.printer.out(), "kmsg failed: {:#}", err).ok();
+                            }
+                        });
+                        self.pv_kmsg = Some(KmsgTask { task: t, mode, req });
+                    }
+                }
+            }
+            ParavisorCommand::Inspect(InspectArgs {
                 recursive,
                 limit,
-                paravisor,
                 update,
                 element,
-            } => {
-                if !paravisor {
-                    anyhow::bail!("no host inspect yet");
-                }
+            }) => {
                 if let Some(update) = update {
                     let value = self
+                        .inner
                         .paravisor_diag
                         .update(element.unwrap_or_default(), update)
                         .await
@@ -219,6 +268,7 @@ impl Vm {
                     println!("{:#}", value);
                 } else {
                     let node = self
+                        .inner
                         .paravisor_diag
                         .inspect(
                             element.unwrap_or_default(),
@@ -286,13 +336,13 @@ impl VmInner {
                     .await
                     .context("failed to open serial port")?;
 
+                    writeln!(self.printer.out(), "com{port} connected").ok();
+
                     current_serial.insert(BufReader::new(
                         PolledPipe::new(&self.driver, new_serial)
                             .context("failed to create polled pipe")?,
                     ))
                 };
-
-                writeln!(self.printer.out(), "COM{port} connected").ok();
 
                 match &mut target {
                     SerialTarget::Printer => {
@@ -301,7 +351,7 @@ impl VmInner {
                             if n == 0 {
                                 break;
                             }
-                            write!(self.printer.out(), "[COM{port}]: {}", line).ok();
+                            write!(self.printer.out(), "[com{port}]: {}", line).ok();
                             line.clear();
                         }
                     }
@@ -310,7 +360,7 @@ impl VmInner {
                     }
                 }
 
-                writeln!(self.printer.out(), "COM{port} disconnected").ok();
+                writeln!(self.printer.out(), "com{port} disconnected").ok();
                 current_serial = None;
                 Ok(())
             };
@@ -333,7 +383,91 @@ impl VmInner {
 
         if let Some(serial) = current_serial {
             drop(serial);
-            writeln!(self.printer.out(), "COM{port} disconnected").ok();
+            writeln!(self.printer.out(), "com{port} disconnected").ok();
+        }
+
+        Ok(())
+    }
+
+    async fn handle_kmsg(
+        &self,
+        mut req: mesh::Receiver<SerialRequest>,
+        mut target: SerialTarget,
+    ) -> anyhow::Result<()> {
+        let mut current = None;
+
+        enum Event {
+            TaskDone(anyhow::Result<()>),
+            Request(Option<SerialRequest>),
+        }
+
+        loop {
+            let task = async {
+                let kmsg = if let Some(kmsg) = &mut current {
+                    kmsg
+                } else {
+                    self.paravisor_diag.wait_for_server().await?;
+                    let new_kmsg = self
+                        .paravisor_diag
+                        .kmsg(true)
+                        .await
+                        .context("failed to open kmsg stream")?;
+
+                    writeln!(self.printer.out(), "kmsg connected").ok();
+
+                    current.insert(new_kmsg)
+                };
+
+                while let Some(data) = kmsg.next().await {
+                    match data {
+                        Ok(data) => {
+                            let message = kmsg::KmsgParsedEntry::new(&data)?;
+                            match &mut target {
+                                SerialTarget::Printer => {
+                                    writeln!(
+                                        self.printer.out(),
+                                        "[kmsg]: {}",
+                                        message.display(true)
+                                    )
+                                    .ok();
+                                }
+                                SerialTarget::Console(console) => {
+                                    let line = format!("{}\r\n", message.display(true));
+                                    console.write_all(line.as_bytes()).await?;
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            eprintln!("kmsg failure: {:#}", anyhow::Error::from(err));
+                            return Ok(());
+                        }
+                    }
+                }
+
+                writeln!(self.printer.out(), "kmsg disconnected").ok();
+                current = None;
+                Ok(())
+            };
+
+            let event = (task.map(Event::TaskDone), req.next().map(Event::Request))
+                .race()
+                .await;
+            match event {
+                Event::TaskDone(r) => r?,
+                Event::Request(Some(y)) => match y {
+                    SerialRequest::NewTarget(new_target) => {
+                        target = new_target;
+                    }
+                },
+                Event::Request(None) => {
+                    break;
+                }
+            }
+        }
+
+        if let Some(kmsg) = current {
+            drop(kmsg);
+            writeln!(self.printer.out(), "kmsg disconnected").ok();
         }
 
         Ok(())

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -87,9 +87,6 @@ impl Vm {
         path: &str,
     ) -> anyhow::Result<inspect::Node> {
         match target {
-            InspectTarget::Host => {
-                anyhow::bail!("host inspect not supported yet");
-            }
             InspectTarget::Paravisor => {
                 self.inner
                     .paravisor_diag

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -38,13 +38,13 @@ pub struct Vm {
 struct SerialTask {
     mode: SerialMode,
     task: Task<()>,
-    req: mesh::Sender<SerialRequest>,
+    req: mesh::Sender<IoRequest>,
 }
 
 struct KmsgTask {
     mode: LogMode,
     task: Task<()>,
-    req: mesh::Sender<SerialRequest>,
+    req: mesh::Sender<IoRequest>,
 }
 
 struct VmInner {
@@ -179,8 +179,8 @@ impl Vm {
                         }
                         None
                     }
-                    SerialMode::Log => Some(SerialTarget::Printer),
-                    SerialMode::Term => Some(SerialTarget::Console(
+                    SerialMode::Log => Some(IoTarget::Printer),
+                    SerialMode::Term => Some(IoTarget::Console(
                         console_relay::Console::new(self.inner.driver.clone(), None)
                             .context("failed to launch console")?,
                     )),
@@ -188,7 +188,7 @@ impl Vm {
                 if let Some(target) = target {
                     if let Some(task) = task {
                         task.mode = mode;
-                        task.req.send(SerialRequest::NewTarget(target));
+                        task.req.send(IoRequest::NewTarget(target));
                     } else {
                         let (req, recv) = mesh::channel();
                         let inner = self.inner.clone();
@@ -229,8 +229,8 @@ impl Vm {
                         }
                         None
                     }
-                    LogMode::Log => Some(SerialTarget::Printer),
-                    LogMode::Term => Some(SerialTarget::Console(
+                    LogMode::Log => Some(IoTarget::Printer),
+                    LogMode::Term => Some(IoTarget::Console(
                         console_relay::Console::new(self.inner.driver.clone(), None)
                             .context("failed to launch console")?,
                     )),
@@ -238,7 +238,7 @@ impl Vm {
                 if let Some(target) = target {
                     if let Some(task) = &mut self.pv_kmsg {
                         task.mode = mode;
-                        task.req.send(SerialRequest::NewTarget(target));
+                        task.req.send(IoRequest::NewTarget(target));
                     } else {
                         let (req, recv) = mesh::channel();
                         let inner = self.inner.clone();
@@ -300,11 +300,11 @@ impl Vm {
     }
 }
 
-enum SerialRequest {
-    NewTarget(SerialTarget),
+enum IoRequest {
+    NewTarget(IoTarget),
 }
 
-enum SerialTarget {
+enum IoTarget {
     Printer,
     Console(console_relay::Console),
 }
@@ -312,15 +312,15 @@ enum SerialTarget {
 impl VmInner {
     async fn handle_serial(
         &self,
-        mut req: mesh::Receiver<SerialRequest>,
-        mut target: SerialTarget,
+        mut req: mesh::Receiver<IoRequest>,
+        mut target: IoTarget,
         port: u32,
     ) -> anyhow::Result<()> {
         let mut current_serial = None;
 
         enum Event {
             TaskDone(anyhow::Result<()>),
-            Request(Option<SerialRequest>),
+            Request(Option<IoRequest>),
         }
 
         loop {
@@ -345,7 +345,7 @@ impl VmInner {
                 };
 
                 match &mut target {
-                    SerialTarget::Printer => {
+                    IoTarget::Printer => {
                         let mut line = String::new();
                         while let Ok(n) = serial.read_line(&mut line).await {
                             if n == 0 {
@@ -355,7 +355,7 @@ impl VmInner {
                             line.clear();
                         }
                     }
-                    SerialTarget::Console(console) => {
+                    IoTarget::Console(console) => {
                         console.relay(serial).await?;
                     }
                 }
@@ -371,7 +371,7 @@ impl VmInner {
             match event {
                 Event::TaskDone(r) => r?,
                 Event::Request(Some(y)) => match y {
-                    SerialRequest::NewTarget(new_target) => {
+                    IoRequest::NewTarget(new_target) => {
                         target = new_target;
                     }
                 },
@@ -391,14 +391,14 @@ impl VmInner {
 
     async fn handle_kmsg(
         &self,
-        mut req: mesh::Receiver<SerialRequest>,
-        mut target: SerialTarget,
+        mut req: mesh::Receiver<IoRequest>,
+        mut target: IoTarget,
     ) -> anyhow::Result<()> {
         let mut current = None;
 
         enum Event {
             TaskDone(anyhow::Result<()>),
-            Request(Option<SerialRequest>),
+            Request(Option<IoRequest>),
         }
 
         loop {
@@ -423,7 +423,7 @@ impl VmInner {
                         Ok(data) => {
                             let message = kmsg::KmsgParsedEntry::new(&data)?;
                             match &mut target {
-                                SerialTarget::Printer => {
+                                IoTarget::Printer => {
                                     writeln!(
                                         self.printer.out(),
                                         "[kmsg]: {}",
@@ -431,7 +431,7 @@ impl VmInner {
                                     )
                                     .ok();
                                 }
-                                SerialTarget::Console(console) => {
+                                IoTarget::Console(console) => {
                                     let line = format!("{}\r\n", message.display(true));
                                     console.write_all(line.as_bytes()).await?;
                                 }
@@ -455,7 +455,7 @@ impl VmInner {
             match event {
                 Event::TaskDone(r) => r?,
                 Event::Request(Some(y)) => match y {
-                    SerialRequest::NewTarget(new_target) => {
+                    IoRequest::NewTarget(new_target) => {
                         target = new_target;
                     }
                 },

--- a/openhcl/diag_client/src/lib.rs
+++ b/openhcl/diag_client/src/lib.rs
@@ -400,10 +400,10 @@ impl DiagClient {
         )
     }
 
-    /// Creates a client from a connector.
+    /// Creates a client from a dialer.
     ///
     /// This client won't be usable with operations that require additional connections.
-    pub fn from_conn(driver: impl Driver + Spawn, conn: impl mesh_rpc::client::Dial) -> Self {
+    pub fn from_dialer(driver: impl Driver + Spawn, conn: impl mesh_rpc::client::Dial) -> Self {
         Self::new(driver, VmType::None, conn)
     }
 

--- a/openhcl/diag_client/src/lib.rs
+++ b/openhcl/diag_client/src/lib.rs
@@ -239,6 +239,7 @@ async fn new_data_connection(
 }
 
 /// Represents different VM types.
+#[derive(Clone)]
 enum VmType {
     /// A Hyper-V VM represented by a VM ID GUID, which uses a VmSocket to connect.
     #[cfg(windows)]
@@ -323,74 +324,119 @@ impl ConnectError {
     }
 }
 
+struct VmConnector {
+    vm: VmType,
+    driver: Box<dyn Driver>,
+}
+
+impl mesh_rpc::client::Dial for VmConnector {
+    type Stream = PolledSocket<socket2::Socket>;
+
+    async fn dial(&mut self) -> std::io::Result<Self::Stream> {
+        match &self.vm {
+            #[cfg(windows)]
+            VmType::HyperV(guid) => {
+                let socket = hyperv::connect_vsock(
+                    self.driver.as_ref(),
+                    *guid,
+                    diag_proto::VSOCK_CONTROL_PORT,
+                )
+                .await
+                .map_err(|err| std::io::Error::new(ErrorKind::Other, err))?;
+                Ok(PolledSocket::new(&self.driver, socket.into())?)
+            }
+            VmType::HybridVsock(path) => {
+                let socket = connect_hybrid_vsock(
+                    self.driver.as_ref(),
+                    path,
+                    diag_proto::VSOCK_CONTROL_PORT,
+                )
+                .await
+                .map_err(|err| std::io::Error::new(ErrorKind::Other, err))?;
+                Ok(socket)
+            }
+            VmType::None => unreachable!(),
+        }
+    }
+}
+
 impl DiagClient {
     /// Creates a client from Hyper-V VM name.
     #[cfg(windows)]
-    pub async fn from_hyperv_name(
-        driver: impl Driver + Spawn,
+    pub fn from_hyperv_name(
+        driver: impl Driver + Spawn + Clone,
         name: &str,
-    ) -> Result<Self, ConnectError> {
-        Self::from_hyperv_id(
+    ) -> anyhow::Result<Self> {
+        Ok(Self::from_hyperv_id(
             driver,
             hyperv::vm_id_from_name(name).map_err(ConnectError::other)?,
-        )
-        .await
+        ))
     }
 
     /// Creates a client from a Hyper-V or HCS VM ID.
     #[cfg(windows)]
-    pub async fn from_hyperv_id(
-        driver: impl Driver + Spawn,
-        vm_id: guid::Guid,
-    ) -> Result<Self, ConnectError> {
-        let socket = hyperv::connect_vsock(&driver, vm_id, diag_proto::VSOCK_CONTROL_PORT).await?;
-        Ok(Self {
-            vm: VmType::HyperV(vm_id),
-            ttrpc: mesh_rpc::Client::new(&driver, socket),
-            driver: Box::new(driver),
-        })
-    }
-
-    /// Creates a client from a Unix socket path.
-    pub async fn from_socket(
-        driver: impl Driver + Spawn,
-        path: &Path,
-    ) -> Result<Self, ConnectError> {
-        let socket = unix_socket::UnixStream::connect(path).map_err(ConnectError::other)?;
-        Ok(Self {
-            vm: VmType::None,
-            ttrpc: mesh_rpc::Client::new(&driver, socket),
-            driver: Box::new(driver),
-        })
+    pub fn from_hyperv_id(driver: impl Driver + Spawn + Clone, vm_id: guid::Guid) -> Self {
+        let vm = VmType::HyperV(vm_id);
+        Self::new(
+            driver.clone(),
+            vm.clone(),
+            VmConnector {
+                vm,
+                driver: Box::new(driver),
+            },
+        )
     }
 
     /// Creates a client from a hybrid vsock Unix socket path.
-    pub async fn from_hybrid_vsock(
-        driver: impl Driver + Spawn,
-        path: &Path,
-    ) -> Result<Self, ConnectError> {
-        let socket = connect_hybrid_vsock(&driver, path, diag_proto::VSOCK_CONTROL_PORT)
-            .await?
-            .into_inner();
-        Ok(Self {
-            vm: VmType::HybridVsock(path.into()),
-            ttrpc: mesh_rpc::Client::new(&driver, socket),
-            driver: Box::new(driver),
-        })
+    pub fn from_hybrid_vsock(driver: impl Driver + Spawn + Clone, path: &Path) -> Self {
+        let vm = VmType::HybridVsock(path.into());
+        Self::new(
+            driver.clone(),
+            vm.clone(),
+            VmConnector {
+                vm,
+                driver: Box::new(driver.clone()),
+            },
+        )
     }
 
-    /// Creates a client from an existing connection.
+    /// Creates a client from a connector.
     ///
     /// This client won't be usable with operations that require additional connections.
-    pub fn from_conn<T>(driver: impl Driver + Spawn, conn: T) -> Self
-    where
-        T: 'static + Send + Sync + pal_async::socket::AsSockRef + std::io::Read + std::io::Write,
-    {
+    pub fn from_conn(driver: impl Driver + Spawn, conn: impl mesh_rpc::client::Dial) -> Self {
+        Self::new(driver, VmType::None, conn)
+    }
+
+    fn new(driver: impl Driver + Spawn, vm: VmType, conn: impl mesh_rpc::client::Dial) -> Self {
         Self {
-            vm: VmType::None,
-            ttrpc: mesh_rpc::Client::new(&driver, conn),
+            vm,
+            ttrpc: mesh_rpc::client::ClientBuilder::new()
+                // Use a short reconnect timeout (compared to the normal 20
+                // seconds) since the VM may start at any time.
+                .retry_timeout(Duration::from_secs(1))
+                .build(&driver, conn),
             driver: Box::new(driver),
         }
+    }
+
+    /// Waits for the paravisor to be ready for RPCs.
+    pub async fn wait_for_server(&self) -> anyhow::Result<()> {
+        match self
+            .ttrpc
+            .call()
+            .wait_ready(true)
+            .start(diag_proto::OpenhclDiag::Ping, ())
+            .await
+        {
+            Ok(()) => {}
+            Err(Status { code, .. }) if code == mesh_rpc::service::Code::Unimplemented as i32 => {
+                // Older versions of the diag server don't support the ping
+                // RPC, but an unimplemented failure is good enough to know
+                // the server is ready.
+            }
+            Err(status) => return Err(grpc_status(status)),
+        }
+        Ok(())
     }
 
     /// Creates a builder for execing a command.
@@ -435,17 +481,18 @@ impl DiagClient {
         depth: Option<usize>,
         timeout: Option<Duration>,
     ) -> anyhow::Result<Node> {
-        let response = self.ttrpc.start_call(
+        let response = self.ttrpc.call().timeout(timeout).start(
             inspect_proto::InspectService::Inspect,
             inspect_proto::InspectRequest {
                 path: path.into(),
                 // It would be better to pass an Option<u32> in the proto, but that would break backcompat.
                 depth: depth.unwrap_or(u32::MAX as usize) as u32,
             },
-            timeout,
         );
 
-        let response = response.upcast::<Result<InspectResponse2, Status>>();
+        let response = response
+            .into_inner()
+            .upcast::<Result<InspectResponse2, Status>>();
         let response = response.await?.map_err(grpc_status)?;
 
         Ok(response.result)
@@ -457,16 +504,17 @@ impl DiagClient {
         path: impl Into<String>,
         value: impl Into<String>,
     ) -> anyhow::Result<inspect::Value> {
-        let response = self.ttrpc.start_call(
+        let response = self.ttrpc.call().start(
             inspect_proto::InspectService::Update,
             inspect_proto::UpdateRequest {
                 path: path.into(),
                 value: value.into(),
             },
-            None,
         );
 
-        let response = response.upcast::<Result<UpdateResponse2, Status>>();
+        let response = response
+            .into_inner()
+            .upcast::<Result<UpdateResponse2, Status>>();
         let response = response.await?.map_err(grpc_status)?;
 
         Ok(response.new_value)
@@ -517,8 +565,9 @@ impl DiagClient {
             args: args.into_iter().collect(),
         };
         self.ttrpc
-            .call(diag_proto::UnderhillDiag::Start, request)
-            .await?
+            .call()
+            .start(diag_proto::UnderhillDiag::Start, request)
+            .await
             .map_err(grpc_status)?;
 
         Ok(())
@@ -529,11 +578,12 @@ impl DiagClient {
         let (conn, socket) = self.connect_data().await?;
 
         self.ttrpc
-            .call(
+            .call()
+            .start(
                 diag_proto::UnderhillDiag::Kmsg,
                 diag_proto::KmsgRequest { follow, conn },
             )
-            .await?
+            .await
             .map_err(grpc_status)?;
 
         Ok(KmsgStream::new(socket))
@@ -548,7 +598,8 @@ impl DiagClient {
         let (conn, socket) = self.connect_data().await?;
 
         self.ttrpc
-            .call(
+            .call()
+            .start(
                 diag_proto::UnderhillDiag::ReadFile,
                 diag_proto::FileRequest {
                     follow,
@@ -556,7 +607,7 @@ impl DiagClient {
                     file_path,
                 },
             )
-            .await?
+            .await
             .map_err(grpc_status)?;
 
         Ok(socket)
@@ -566,28 +617,19 @@ impl DiagClient {
     ///
     /// This can be used to support extension RPCs that are not part of the main
     /// diagnostics service.
-    pub fn custom_call<F, R, T, U>(
-        &self,
-        rpc: F,
-        input: T,
-        timeout: Option<Duration>,
-    ) -> mesh::OneshotReceiver<Result<U, Status>>
-    where
-        F: FnOnce(T, mesh::OneshotSender<Result<U, Status>>) -> R,
-        R: mesh_rpc::service::ServiceRpc,
-        U: mesh::MeshPayload,
-    {
-        self.ttrpc.start_call(rpc, input, timeout)
+    pub fn custom_call(&self) -> mesh_rpc::client::CallBuilder<'_> {
+        self.ttrpc.call()
     }
 
     /// Crashes the VM.
     pub async fn crash(&self, pid: i32) -> anyhow::Result<()> {
         self.ttrpc
-            .call(
+            .call()
+            .start(
                 diag_proto::UnderhillDiag::Crash,
                 diag_proto::CrashRequest { pid },
             )
-            .await?
+            .await
             .map_err(grpc_status)?;
 
         Ok(())
@@ -625,14 +667,15 @@ impl DiagClient {
 
         let response = self
             .ttrpc
-            .call(
+            .call()
+            .start(
                 diag_proto::UnderhillDiag::PacketCapture,
                 diag_proto::NetworkPacketCaptureRequest {
                     operation: operation.into(),
                     op_data,
                 },
             )
-            .await?
+            .await
             .map_err(grpc_status)?;
 
         Ok((sockets, response.num_streams))
@@ -689,8 +732,9 @@ impl DiagClient {
     /// Restarts the Underhill worker.
     pub async fn restart(&self) -> anyhow::Result<()> {
         self.ttrpc
-            .call(diag_proto::UnderhillDiag::Restart, ())
-            .await?
+            .call()
+            .start(diag_proto::UnderhillDiag::Restart, ())
+            .await
             .map_err(grpc_status)?;
 
         Ok(())
@@ -699,8 +743,9 @@ impl DiagClient {
     /// Pause the VM (including all devices).
     pub async fn pause(&self) -> anyhow::Result<()> {
         self.ttrpc
-            .call(diag_proto::UnderhillDiag::Pause, ())
-            .await?
+            .call()
+            .start(diag_proto::UnderhillDiag::Pause, ())
+            .await
             .map_err(grpc_status)?;
 
         Ok(())
@@ -709,8 +754,9 @@ impl DiagClient {
     /// Resume the VM.
     pub async fn resume(&self) -> anyhow::Result<()> {
         self.ttrpc
-            .call(diag_proto::UnderhillDiag::Resume, ())
-            .await?
+            .call()
+            .start(diag_proto::UnderhillDiag::Resume, ())
+            .await
             .map_err(grpc_status)?;
 
         Ok(())
@@ -720,8 +766,9 @@ impl DiagClient {
     pub async fn dump_saved_state(&self) -> anyhow::Result<Vec<u8>> {
         let state = self
             .ttrpc
-            .call(diag_proto::UnderhillDiag::DumpSavedState, ())
-            .await?
+            .call()
+            .start(diag_proto::UnderhillDiag::DumpSavedState, ())
+            .await
             .map_err(grpc_status)?;
 
         Ok(state.data)
@@ -858,14 +905,14 @@ impl ExecBuilder<'_> {
         let response = self
             .client
             .ttrpc
-            .call(diag_proto::UnderhillDiag::Exec, request)
-            .await?
+            .call()
+            .start(diag_proto::UnderhillDiag::Exec, request)
+            .await
             .map_err(grpc_status)?;
 
-        let wait = self.client.ttrpc.start_call(
+        let wait = self.client.ttrpc.call().start(
             diag_proto::UnderhillDiag::Wait,
             WaitRequest { pid: response.pid },
-            None,
         );
 
         Ok(Process {
@@ -888,7 +935,7 @@ pub struct Process {
     /// The standard error stream.
     pub stderr: Option<socket2::Socket>,
     pid: i32,
-    wait: mesh::OneshotReceiver<Result<WaitResponse, Status>>,
+    wait: mesh_rpc::client::Call<WaitResponse>,
 }
 
 impl Process {
@@ -902,7 +949,6 @@ impl Process {
         let response = self
             .wait
             .await
-            .context("disconnected")?
             .map_err(|err| anyhow::anyhow!("{}", err.message))?;
 
         Ok(ExitStatus { response })

--- a/openhcl/diag_proto/src/diag.proto
+++ b/openhcl/diag_proto/src/diag.proto
@@ -7,6 +7,16 @@ package diag;
 
 import "google/protobuf/empty.proto";
 
+// OpenHCL diagnostics services.
+//
+// Add new methods here, since the diagnostics service in use before this did
+// not handle unknown methods correctly.
+service OpenhclDiag {
+    // Ping the server, validating it is ready for use.
+    rpc Ping(google.protobuf.Empty) returns (google.protobuf.Empty);
+}
+
+// Older methods.
 service UnderhillDiag {
     rpc Exec(ExecRequest) returns (ExecResponse);
     rpc Wait(WaitRequest) returns (WaitResponse);

--- a/openhcl/diag_server/src/diag_service.rs
+++ b/openhcl/diag_server/src/diag_service.rs
@@ -15,6 +15,7 @@ use diag_proto::FileRequest;
 use diag_proto::KmsgRequest;
 use diag_proto::NetworkPacketCaptureRequest;
 use diag_proto::NetworkPacketCaptureResponse;
+use diag_proto::OpenhclDiag;
 use diag_proto::StartRequest;
 use diag_proto::UnderhillDiag;
 use diag_proto::WaitRequest;
@@ -128,16 +129,19 @@ impl DiagServiceHandler {
         self: &Arc<Self>,
         driver: &(impl Driver + Spawn + Clone),
         diag_recv: mesh::Receiver<(CancelContext, UnderhillDiag)>,
+        diag2_recv: mesh::Receiver<(CancelContext, OpenhclDiag)>,
         inspect_recv: mesh::Receiver<(CancelContext, InspectService)>,
         profile_recv: mesh::Receiver<(CancelContext, AzureProfiler)>,
     ) -> anyhow::Result<()> {
         enum Event {
             Diag(UnderhillDiag),
+            Diag2(OpenhclDiag),
             Inspect(InspectService),
             Profile(AzureProfiler),
         }
         let mut s = (
             diag_recv.map(|(ctx, req)| (ctx, Event::Diag(req))),
+            diag2_recv.map(|(ctx, req)| (ctx, Event::Diag2(req))),
             inspect_recv.map(|(ctx, req)| (ctx, Event::Inspect(req))),
             profile_recv.map(|(ctx, req)| (ctx, Event::Profile(req))),
         )
@@ -151,6 +155,7 @@ impl DiagServiceHandler {
                     async move {
                         match req {
                             Event::Diag(req) => this.handle_diag_request(&driver, req, ctx).await,
+                            Event::Diag2(req) => this.handle_diag2_request(&driver, req, ctx).await,
                             Event::Inspect(req) => this.handle_inspect_request(req, ctx).await,
                             Event::Profile(req) => this.handle_profile_request(req, ctx).await,
                         }
@@ -241,6 +246,19 @@ impl DiagServiceHandler {
             UnderhillDiag::DumpSavedState((), response) => response.send(grpc_result(
                 ctx.until_cancelled(self.handle_dump_saved_state()).await,
             )),
+        }
+    }
+
+    async fn handle_diag2_request(
+        &self,
+        _driver: &(impl Driver + Spawn + Clone),
+        req: OpenhclDiag,
+        _ctx: CancelContext,
+    ) {
+        match req {
+            OpenhclDiag::Ping((), response) => {
+                response.send(Ok(()));
+            }
         }
     }
 

--- a/openhcl/diag_server/src/lib.rs
+++ b/openhcl/diag_server/src/lib.rs
@@ -98,11 +98,13 @@ impl DiagServer {
         request_send: mesh::Sender<DiagRequest>,
     ) -> anyhow::Result<()> {
         let (diag_send, diag_recv) = mesh::channel();
+        let (diag2_send, diag2_recv) = mesh::channel();
         let (inspect_send, inspect_recv) = mesh::channel();
         // Disable all diag requests for CVMs. Inspect filtering will be handled
         // internally more granularly.
         if !underhill_confidentiality::confidential_filtering_enabled() {
             self.server.add_service(diag_send);
+            self.server.add_service(diag2_send);
         }
 
         self.server.add_service(inspect_send);
@@ -115,7 +117,13 @@ impl DiagServer {
             request_send,
             self.inner.clone(),
         ));
-        let process = diag_service.process_requests(driver, diag_recv, inspect_recv, profile_recv);
+        let process = diag_service.process_requests(
+            driver,
+            diag_recv,
+            diag2_recv,
+            inspect_recv,
+            profile_recv,
+        );
 
         let serve = self.server.run(driver, self.control_listener, cancel);
         let data_connections = self

--- a/openhcl/ohcldiag-dev/Cargo.toml
+++ b/openhcl/ohcldiag-dev/Cargo.toml
@@ -19,13 +19,13 @@ term.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 ctrlc.workspace = true
-env_logger.workspace = true
 fs-err.workspace = true
 futures.workspace = true
 futures-concurrency.workspace = true
 kmsg.workspace = true
 socket2.workspace = true
 thiserror.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 unicycle.workspace = true
 
 [lints]

--- a/openhcl/ohcldiag-dev/src/completions.rs
+++ b/openhcl/ohcldiag-dev/src/completions.rs
@@ -38,9 +38,7 @@ impl CustomCompleterFactory for OhcldiagDevCompleteFactory {
     async fn build(&self, ctx: &clap_dyn_complete::RootCtx<'_>) -> Self::CustomCompleter {
         let vm = ctx.matches.try_get_one::<VmId>("VM").unwrap_or_default();
         let client = if let Some(vm) = vm {
-            new_client(self.driver.clone(), &VmArg { id: vm.clone() })
-                .await
-                .ok()
+            new_client(self.driver.clone(), &VmArg { id: vm.clone() }).ok()
         } else {
             None
         };

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -77,7 +77,6 @@ use mesh_worker::WorkerEvent;
 use mesh_worker::WorkerHandle;
 use meshworker::VmmMesh;
 use net_backend_resources::mac_address::MacAddress;
-use pal_async::driver::Driver;
 use pal_async::pipe::PolledPipe;
 use pal_async::socket::PolledSocket;
 use pal_async::task::Spawn;
@@ -1829,15 +1828,20 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
         vm_rpc.call(VmRpc::Resume, ()).await?;
     }
 
-    let mut diag_inspector = DiagInspector::new(
+    let paravisor_diag = Arc::new(diag_client::DiagClient::from_conn(
         driver.clone(),
-        vm_rpc.clone(),
-        if opt.vtl2 {
-            DeviceVtl::Vtl2
-        } else {
-            DeviceVtl::Vtl0
+        DiagConnector {
+            driver: driver.clone(),
+            vm_rpc: vm_rpc.clone(),
+            openhcl_vtl: if opt.vtl2 {
+                DeviceVtl::Vtl2
+            } else {
+                DeviceVtl::Vtl0
+            },
         },
-    );
+    ));
+
+    let mut diag_inspector = DiagInspector::new(driver.clone(), paravisor_diag.clone());
 
     let (console_command_send, console_command_recv) = mesh::channel();
     let (inspect_completion_engine_send, inspect_completion_engine_recv) = mesh::channel();
@@ -2522,9 +2526,8 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
                 let r = async {
                     let start;
                     if user_mode_only {
-                        let diag = connect_diag(driver.clone(), &vm_rpc, DeviceVtl::Vtl2).await?;
                         start = Instant::now();
-                        diag.restart().await?;
+                        paravisor_diag.restart().await?;
                     } else {
                         let path = igvm
                             .as_ref()
@@ -2670,24 +2673,32 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
     Ok(())
 }
 
-async fn connect_diag(
-    driver: impl Driver + Spawn,
-    vm_rpc: &mesh::Sender<VmRpc>,
+struct DiagConnector {
+    driver: DefaultDriver,
+    vm_rpc: Arc<mesh::Sender<VmRpc>>,
     openhcl_vtl: DeviceVtl,
-) -> anyhow::Result<diag_client::DiagClient> {
-    let service_id = new_hvsock_service_id(1);
-    let socket = vm_rpc
-        .call_failable(
-            VmRpc::ConnectHvsock,
-            (
-                CancelContext::new().with_timeout(Duration::from_secs(2)),
-                service_id,
-                openhcl_vtl,
-            ),
-        )
-        .await?;
-    let diag_client = diag_client::DiagClient::from_conn(driver, socket);
-    Ok(diag_client)
+}
+
+impl mesh_rpc::client::Dial for DiagConnector {
+    type Stream = PolledSocket<unix_socket::UnixStream>;
+
+    async fn dial(&mut self) -> io::Result<Self::Stream> {
+        let service_id = new_hvsock_service_id(1);
+        let socket = self
+            .vm_rpc
+            .call_failable(
+                VmRpc::ConnectHvsock,
+                (
+                    CancelContext::new().with_timeout(Duration::from_secs(2)),
+                    service_id,
+                    self.openhcl_vtl,
+                ),
+            )
+            .await
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+
+        Ok(PolledSocket::new(&self.driver, socket)?)
+    }
 }
 
 /// An object that implements [`InspectMut`] by sending an inspect request over
@@ -2699,11 +2710,7 @@ async fn connect_diag(
 pub struct DiagInspector(DiagInspectorInner);
 
 enum DiagInspectorInner {
-    NotStarted {
-        driver: DefaultDriver,
-        vm_rpc: Arc<mesh::Sender<VmRpc>>,
-        openhcl_vtl: DeviceVtl,
-    },
+    NotStarted(DefaultDriver, Arc<diag_client::DiagClient>),
     Started {
         send: mesh::Sender<inspect::Deferred>,
         _task: Task<()>,
@@ -2712,34 +2719,23 @@ enum DiagInspectorInner {
 }
 
 impl DiagInspector {
-    pub fn new(
-        driver: DefaultDriver,
-        vm_rpc: Arc<mesh::Sender<VmRpc>>,
-        openhcl_vtl: DeviceVtl,
-    ) -> Self {
-        Self(DiagInspectorInner::NotStarted {
-            driver,
-            vm_rpc,
-            openhcl_vtl,
-        })
+    pub fn new(driver: DefaultDriver, diag_client: Arc<diag_client::DiagClient>) -> Self {
+        Self(DiagInspectorInner::NotStarted(driver, diag_client))
     }
 
     fn start(&mut self) -> &mesh::Sender<inspect::Deferred> {
         loop {
             match self.0 {
                 DiagInspectorInner::NotStarted { .. } => {
-                    let DiagInspectorInner::NotStarted {
-                        driver,
-                        vm_rpc,
-                        openhcl_vtl,
-                    } = std::mem::replace(&mut self.0, DiagInspectorInner::Invalid)
+                    let DiagInspectorInner::NotStarted(driver, client) =
+                        std::mem::replace(&mut self.0, DiagInspectorInner::Invalid)
                     else {
                         unreachable!()
                     };
                     let (send, recv) = mesh::channel();
-                    let task = driver
-                        .clone()
-                        .spawn("diag-inspect", Self::run(driver, vm_rpc, recv, openhcl_vtl));
+                    let task = driver.clone().spawn("diag-inspect", async move {
+                        Self::run(&client, recv).await
+                    });
 
                     self.0 = DiagInspectorInner::Started { send, _task: task };
                 }
@@ -2750,28 +2746,10 @@ impl DiagInspector {
     }
 
     async fn run(
-        driver: DefaultDriver,
-        vm_rpc: Arc<mesh::Sender<VmRpc>>,
+        diag_client: &diag_client::DiagClient,
         mut recv: mesh::Receiver<inspect::Deferred>,
-        openhcl_vtl: DeviceVtl,
     ) {
-        let mut last_client = None;
         while let Some(deferred) = recv.next().await {
-            let client = if let Some(client) = &mut last_client {
-                client
-            } else {
-                match connect_diag(driver.clone(), &vm_rpc, openhcl_vtl).await {
-                    Ok(client) => last_client.insert(client),
-                    Err(err) => {
-                        deferred.complete_external(
-                            inspect::Node::Failed(inspect::Error::Mesh(format!("{err:#}"))),
-                            inspect::SensitivityLevel::Unspecified,
-                        );
-                        continue;
-                    }
-                }
-            };
-
             let info = deferred.external_request();
             let result = match info.request_type {
                 inspect::ExternalRequestType::Inspect { depth } => {
@@ -2779,18 +2757,17 @@ impl DiagInspector {
                         Ok(inspect::Node::Unevaluated)
                     } else {
                         // TODO: Support taking timeouts from the command line
-                        client
+                        diag_client
                             .inspect(info.path, Some(depth - 1), Some(Duration::from_secs(1)))
                             .await
                     }
                 }
                 inspect::ExternalRequestType::Update { value } => {
-                    (client.update(info.path, value).await).map(inspect::Node::Value)
+                    (diag_client.update(info.path, value).await).map(inspect::Node::Value)
                 }
             };
             deferred.complete_external(
                 result.unwrap_or_else(|err| {
-                    last_client = None;
                     inspect::Node::Failed(inspect::Error::Mesh(format!("{err:#}")))
                 }),
                 inspect::SensitivityLevel::Unspecified,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1828,9 +1828,9 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
         vm_rpc.call(VmRpc::Resume, ()).await?;
     }
 
-    let paravisor_diag = Arc::new(diag_client::DiagClient::from_conn(
+    let paravisor_diag = Arc::new(diag_client::DiagClient::from_dialer(
         driver.clone(),
-        DiagConnector {
+        DiagDialer {
             driver: driver.clone(),
             vm_rpc: vm_rpc.clone(),
             openhcl_vtl: if opt.vtl2 {
@@ -2673,13 +2673,13 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
     Ok(())
 }
 
-struct DiagConnector {
+struct DiagDialer {
     driver: DefaultDriver,
     vm_rpc: Arc<mesh::Sender<VmRpc>>,
     openhcl_vtl: DeviceVtl,
 }
 
-impl mesh_rpc::client::Dial for DiagConnector {
+impl mesh_rpc::client::Dial for DiagDialer {
     type Stream = PolledSocket<unix_socket::UnixStream>;
 
     async fn dial(&mut self) -> io::Result<Self::Stream> {

--- a/petri/src/openhcl_diag.rs
+++ b/petri/src/openhcl_diag.rs
@@ -5,17 +5,10 @@ use anyhow::Context;
 use diag_client::DiagClient;
 use diag_client::ExitStatus;
 use futures::io::AllowStdIo;
-use get_resources::ged::GuestEmulationRequest;
-use mesh::rpc::RpcSend;
-use mesh::Sender;
-use pal_async::DefaultDriver;
 use std::io::Read;
-use std::path::PathBuf;
-use std::sync::Arc;
 
 pub(crate) struct OpenHclDiagHandler {
-    pub(crate) vtl2_vsock_path: PathBuf,
-    pub(crate) ged_send: Arc<Sender<GuestEmulationRequest>>,
+    pub(crate) client: DiagClient,
 }
 
 /// The result of running a VTL2 command.
@@ -35,20 +28,12 @@ pub(crate) struct Vtl2CommandResult {
 }
 
 impl OpenHclDiagHandler {
-    pub(crate) async fn wait_for_vtl2(&self) -> anyhow::Result<()> {
-        self.ged_send
-            .call(GuestEmulationRequest::WaitForConnect, ())
-            .await
-            .context("failed to connect to VTL2")
-    }
-
     pub(crate) async fn run_vtl2_command(
         &self,
-        driver: &DefaultDriver,
         command: impl AsRef<str>,
         args: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> anyhow::Result<Vtl2CommandResult> {
-        let client = self.diag_client(driver).await?;
+        let client = self.diag_client().await?;
         let mut proc = client
             .exec(command.as_ref())
             .args(args)
@@ -82,13 +67,8 @@ impl OpenHclDiagHandler {
         })
     }
 
-    pub(crate) async fn core_dump(
-        &self,
-        driver: &DefaultDriver,
-        name: &str,
-        path: &std::path::Path,
-    ) -> anyhow::Result<()> {
-        let client = self.diag_client(driver).await?;
+    pub(crate) async fn core_dump(&self, name: &str, path: &std::path::Path) -> anyhow::Result<()> {
+        let client = self.diag_client().await?;
         let pid = client.get_pid(name).await?;
         client
             .core_dump(
@@ -100,25 +80,22 @@ impl OpenHclDiagHandler {
             .await
     }
 
-    pub(crate) async fn crash(&self, driver: &DefaultDriver, name: &str) -> anyhow::Result<()> {
-        let client = self.diag_client(driver).await?;
+    pub(crate) async fn crash(&self, name: &str) -> anyhow::Result<()> {
+        let client = self.diag_client().await?;
         let pid = client.get_pid(name).await?;
         client.crash(pid).await
     }
 
-    pub(crate) async fn test_inspect(&self, driver: &DefaultDriver) -> anyhow::Result<()> {
-        self.diag_client(driver)
+    pub(crate) async fn test_inspect(&self) -> anyhow::Result<()> {
+        self.diag_client()
             .await?
             .inspect("", None, None)
             .await
             .map(|_| ())
     }
 
-    async fn diag_client(&self, driver: &DefaultDriver) -> anyhow::Result<DiagClient> {
-        self.wait_for_vtl2().await?;
-        Ok(DiagClient::from_hybrid_vsock(
-            driver.clone(),
-            &self.vtl2_vsock_path,
-        ))
+    async fn diag_client(&self) -> anyhow::Result<&DiagClient> {
+        self.client.wait_for_server().await?;
+        Ok(&self.client)
     }
 }

--- a/petri/src/openhcl_diag.rs
+++ b/petri/src/openhcl_diag.rs
@@ -116,8 +116,9 @@ impl OpenHclDiagHandler {
 
     async fn diag_client(&self, driver: &DefaultDriver) -> anyhow::Result<DiagClient> {
         self.wait_for_vtl2().await?;
-        DiagClient::from_hybrid_vsock(driver.clone(), &self.vtl2_vsock_path)
-            .await
-            .map_err(anyhow::Error::from)
+        Ok(DiagClient::from_hybrid_vsock(
+            driver.clone(),
+            &self.vtl2_vsock_path,
+        ))
     }
 }

--- a/petri/src/vm/construct.rs
+++ b/petri/src/vm/construct.rs
@@ -194,8 +194,10 @@ impl PetriVmConfig {
                         vmbusproxy_handle: None,
                     }),
                     Some(OpenHclDiagHandler {
-                        ged_send: ged_send.clone(),
-                        vtl2_vsock_path,
+                        client: diag_client::DiagClient::from_hybrid_vsock(
+                            driver.clone(),
+                            &vtl2_vsock_path,
+                        ),
                     }),
                     Some(ged),
                     Some(ged_send),

--- a/petri/src/vm/start.rs
+++ b/petri/src/vm/start.rs
@@ -329,13 +329,7 @@ impl PetriVmConfig {
                 );
 
                 let diag_client =
-                    match DiagClient::from_hybrid_vsock(driver2, &vtl2_vsock_path).await {
-                        Err(e) => {
-                            tracing::error!(?e, "Failed to connect to VTL2 diag server");
-                            return;
-                        }
-                        Ok(diag_client) => diag_client,
-                    };
+                     DiagClient::from_hybrid_vsock(driver2, &vtl2_vsock_path);
 
                 let output = match diag_client.inspect("", None, None).await {
                     Err(e) => {

--- a/support/mesh/mesh_rpc/Cargo.toml
+++ b/support/mesh/mesh_rpc/Cargo.toml
@@ -13,6 +13,7 @@ grpc = ["dep:base64", "dep:h2", "dep:tokio", "dep:http", "dep:urlencoding"]
 mesh = { workspace = true, features = ["prost"] }
 pal_async.workspace = true
 test_with_tracing.workspace = true
+unix_socket.workspace = true
 
 anyhow.workspace = true
 futures.workspace = true

--- a/support/mesh/mesh_rpc/src/client.rs
+++ b/support/mesh/mesh_rpc/src/client.rs
@@ -17,19 +17,32 @@ use crate::service::Code;
 use crate::service::GenericRpc;
 use crate::service::ServiceRpc;
 use crate::service::Status;
-use anyhow::Context;
+use anyhow::Context as _;
+use futures::AsyncRead;
+use futures::AsyncReadExt;
+use futures::AsyncWrite;
+use futures::FutureExt;
+use futures::StreamExt;
 use futures_concurrency::future::Race;
+use mesh::payload::EncodeAs;
+use mesh::payload::Timestamp;
+use mesh::Deadline;
 use mesh::MeshPayload;
 use pal_async::driver::Driver;
-use pal_async::socket::AsSockRef;
 use pal_async::socket::PolledSocket;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
+use pal_async::timer::Instant;
+use pal_async::timer::PolledTimer;
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::io::Read;
-use std::io::Write;
+use std::collections::VecDeque;
+use std::future::pending;
+use std::future::Future;
+use std::pin::pin;
+use std::task::ready;
 use std::time::Duration;
+use unix_socket::UnixStream;
 
 /// A TTRPC client connection.
 pub struct Client {
@@ -40,37 +53,349 @@ pub struct Client {
 #[derive(MeshPayload)]
 struct ClientRequest<T> {
     service: String,
-    timeout: Option<u64>,
+    deadline: Option<EncodeAs<Deadline, Timestamp>>,
+    wait_ready: bool,
     rpc: T,
 }
 
-impl Client {
-    /// Creates a new client from a connection.
-    pub fn new<T>(driver: &(impl Driver + Spawn + ?Sized), conn: T) -> Self
-    where
-        T: 'static + Send + Sync + AsSockRef + Read + Write,
-    {
-        let (send, recv) = mesh::channel();
-        let conn = PolledSocket::new(driver, conn).unwrap();
-        let task = (&driver).spawn("ttrpc client", async move {
-            if let Err(err) = Self::run(conn, recv).await {
-                tracing::error!(
-                    error = err.as_ref() as &dyn std::error::Error,
-                    "client error"
-                );
-            }
-        });
+/// Dials a connection to a server.
+pub trait Dial: 'static + Send {
+    /// A bidirectional byte stream connection to the server.
+    type Stream: 'static + Send + AsyncRead + AsyncWrite;
+
+    /// Connects to the server.
+    fn dial(&mut self) -> impl Future<Output = std::io::Result<Self::Stream>> + Send;
+}
+
+/// A [`Dial`] implementation that connects to a Unix domain socket.
+pub struct UnixDialier<T>(T, std::path::PathBuf);
+
+impl<T: Driver> UnixDialier<T> {
+    /// Returns a new dialier that connects to `path`.
+    pub fn new(driver: T, path: impl Into<std::path::PathBuf>) -> Self {
+        Self(driver, path.into())
+    }
+}
+
+impl<T: Driver> Dial for UnixDialier<T> {
+    type Stream = PolledSocket<UnixStream>;
+
+    fn dial(&mut self) -> impl Future<Output = std::io::Result<Self::Stream>> + Send {
+        PolledSocket::connect_unix(&self.0, &self.1)
+    }
+}
+
+/// A [`Dial`] implementation that uses an existing connection.
+///
+/// Once the connection terminates, subsequent connections will fail.
+pub struct ExistingConnection<T>(Option<T>);
+
+impl<T: 'static + Send + AsyncRead + AsyncWrite> ExistingConnection<T> {
+    /// Returns a new dialier that uses `socket`, once.
+    pub fn new(socket: T) -> Self {
+        Self(Some(socket))
+    }
+}
+
+impl<T: 'static + Send + AsyncRead + AsyncWrite> Dial for ExistingConnection<T> {
+    type Stream = T;
+
+    async fn dial(&mut self) -> std::io::Result<Self::Stream> {
+        self.0.take().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::AddrNotAvailable,
+                "connection already used",
+            )
+        })
+    }
+}
+
+/// A builder for [`Client`].
+pub struct ClientBuilder {
+    retry_timeout: Duration,
+}
+
+impl ClientBuilder {
+    /// Returns a new client builder.
+    pub fn new() -> Self {
         Self {
+            // Use the gRPC default.
+            retry_timeout: Duration::from_secs(20),
+        }
+    }
+
+    /// Sets the timeout for a failed connection before attempting to reconnect.
+    pub fn retry_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.retry_timeout = timeout;
+        self
+    }
+
+    /// Builds a new client from a dialier.
+    pub fn build(&self, driver: &(impl Driver + Spawn), dialer: impl Dial) -> Client {
+        let (send, recv) = mesh::channel();
+        let worker = ClientWorker {
+            timer: PolledTimer::new(driver),
+            failure_timer: PolledTimer::new(driver),
+            dialer,
+            waiting: VecDeque::new(),
+            rpc_recv: Some(recv),
+            last_failure: None,
+            failure_timeout: self.retry_timeout,
+        };
+        let task = driver.spawn("ttrpc client", worker.run());
+        Client {
             send: send.force_downcast(),
             task,
         }
     }
+}
 
-    async fn run(
-        stream: PolledSocket<impl AsSockRef + Read + Write>,
-        mut rpc_recv: mesh::Receiver<ClientRequest<GenericRpc>>,
-    ) -> anyhow::Result<()> {
-        let (mut reader, mut writer) = stream.split();
+impl Client {
+    /// Creates a new client from a dialer.
+    pub fn new(driver: &(impl Driver + Spawn), dialer: impl Dial) -> Self {
+        ClientBuilder::new().build(driver, dialer)
+    }
+
+    /// Returns a [`CallBuilder`] to build RPCs.
+    pub fn call(&self) -> CallBuilder<'_> {
+        CallBuilder {
+            client: self,
+            deadline: None,
+            wait_ready: false,
+        }
+    }
+
+    /// Shuts down the client, waiting for the associated task to complete.
+    pub async fn shutdown(self) {
+        drop(self.send);
+        self.task.await;
+    }
+}
+
+/// A builder for RPCs returned by [`Client::call`].
+pub struct CallBuilder<'a> {
+    client: &'a Client,
+    deadline: Option<Deadline>,
+    wait_ready: bool,
+}
+
+/// A future representing an RPC call.
+pub struct Call<T>(mesh::OneshotReceiver<Result<T, Status>>);
+
+impl<T> std::fmt::Debug for Call<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("CallFuture").field(&self.0).finish()
+    }
+}
+
+impl CallBuilder<'_> {
+    /// Sets the timeout for the RPC.
+    ///
+    /// Internally, this will immediately compute a deadline that is `timeout` from now.
+    pub fn timeout(&mut self, timeout: Option<Duration>) -> &mut Self {
+        self.deadline = timeout.and_then(|timeout| Deadline::now().checked_add(timeout));
+        self
+    }
+
+    /// Sets the deadline for the RPC.
+    pub fn deadline(&mut self, deadline: Option<Deadline>) -> &mut Self {
+        self.deadline = deadline;
+        self
+    }
+
+    /// Sets whether the client should wait for the server to be ready before
+    /// sending the RPC.
+    ///
+    /// If this is not set and a connection to the server cannot be established,
+    /// the RPC will fail. Otherwise, the RPC will keep waiting for a connection
+    /// until its deadline.
+    pub fn wait_ready(&mut self, wait_ready: bool) -> &mut Self {
+        self.wait_ready = wait_ready;
+        self
+    }
+
+    /// Starts the RPC.
+    ///
+    /// To get the RPC result, `await` the returned future.
+    #[must_use]
+    pub fn start<F, R, T, U>(&self, rpc: F, input: T) -> Call<U>
+    where
+        F: FnOnce(T, mesh::OneshotSender<Result<U, Status>>) -> R,
+        R: ServiceRpc,
+        U: MeshPayload,
+    {
+        let (send, recv) = mesh::oneshot();
+
+        self.client.send.send(mesh::Message::new(ClientRequest {
+            service: R::NAME.to_string(),
+            deadline: self.deadline.map(Into::into),
+            rpc: rpc(input, send),
+            wait_ready: self.wait_ready,
+        }));
+
+        Call(recv)
+    }
+}
+
+impl<T> Call<T> {
+    /// Returns the inner mesh receiver.
+    pub fn into_inner(self) -> mesh::OneshotReceiver<Result<T, Status>> {
+        self.0
+    }
+}
+
+impl<T: 'static + Send> Future for Call<T> {
+    type Output = Result<T, Status>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        match ready!(self.get_mut().0.poll_unpin(cx)) {
+            Ok(r) => r,
+            Err(err) => Err(Status {
+                code: Code::Unavailable as i32,
+                message: format!("client shut down: {:#}", err),
+                details: Vec::new(),
+            }),
+        }
+        .into()
+    }
+}
+
+struct ClientWorker<T> {
+    dialer: T,
+    timer: PolledTimer,
+    failure_timer: PolledTimer,
+    waiting: VecDeque<ClientRequest<GenericRpc>>,
+    rpc_recv: Option<mesh::Receiver<ClientRequest<GenericRpc>>>,
+    last_failure: Option<Instant>,
+    failure_timeout: Duration,
+}
+
+impl<T: Dial> ClientWorker<T> {
+    async fn run(mut self) {
+        loop {
+            let r = match self.wait_connect().await {
+                None => break,
+                Some(Ok(stream)) => {
+                    tracing::debug!("connection established");
+                    self.run_connection(stream).await.inspect_err(|err| {
+                        tracing::debug!(
+                            error = err.as_ref() as &dyn std::error::Error,
+                            "connection failed"
+                        );
+                    })
+                }
+                Some(Err(err)) => {
+                    tracing::debug!(error = &err as &dyn std::error::Error, "failed to connect");
+                    Err(err.into())
+                }
+            };
+            if let Err(err) = r {
+                self.waiting.retain_mut(|req| {
+                    if req.wait_ready {
+                        return true;
+                    }
+                    req.rpc
+                        .port
+                        .send(mesh::Message::new(Err::<Vec<u8>, Status>(Status {
+                            code: Code::Unavailable as i32,
+                            message: format!("{:#}", err),
+                            details: Vec::new(),
+                        })));
+                    false
+                });
+                self.last_failure = Some(Instant::now());
+            }
+        }
+        tracing::debug!("shutting down");
+    }
+
+    async fn wait_connect(&mut self) -> Option<std::io::Result<T::Stream>> {
+        let mut dial = pin!(self.dialer.dial());
+        while self.rpc_recv.is_some() || !self.waiting.is_empty() {
+            let oldest_deadline = self
+                .waiting
+                .iter()
+                .filter_map(|v| v.deadline.map(|d| *d))
+                .min();
+            let sleep = async {
+                if let Some(deadline) = oldest_deadline {
+                    self.timer.sleep(deadline - Deadline::now()).await;
+                } else {
+                    pending().await
+                }
+            };
+            let next = async {
+                if let Some(recv) = &mut self.rpc_recv {
+                    recv.next().await
+                } else {
+                    pending().await
+                }
+            };
+            let connect = async {
+                if !self.waiting.is_empty() {
+                    if let Some(last_failure) = self.last_failure {
+                        self.failure_timer
+                            .sleep_until(last_failure + self.failure_timeout)
+                            .await;
+                    }
+                    (&mut dial).await
+                } else {
+                    pending().await
+                }
+            };
+
+            enum Event<T> {
+                Request(Option<ClientRequest<GenericRpc>>),
+                Timeout(()),
+                Connect(std::io::Result<T>),
+            }
+
+            match (
+                connect.map(Event::Connect),
+                next.map(Event::Request),
+                sleep.map(Event::Timeout),
+            )
+                .race()
+                .await
+            {
+                Event::Request(req) => {
+                    if let Some(req) = req {
+                        self.waiting.push_back(req);
+                    } else {
+                        self.rpc_recv = None;
+                    }
+                }
+                Event::Timeout(()) => {
+                    let now = Deadline::now();
+                    self.waiting.retain_mut(|req| {
+                        if let Some(deadline) = req.deadline {
+                            if *deadline > now {
+                                req.rpc.port.send(mesh::Message::new(Err::<Vec<u8>, Status>(
+                                    Status {
+                                        code: Code::DeadlineExceeded as i32,
+                                        message: "deadline exceeded".to_string(),
+                                        details: Vec::new(),
+                                    },
+                                )));
+                                return false;
+                            }
+                        }
+                        false
+                    });
+                }
+                Event::Connect(r) => {
+                    return Some(r);
+                }
+            }
+        }
+        None
+    }
+
+    async fn run_connection(&mut self, stream: T::Stream) -> anyhow::Result<()> {
+        let (mut reader, mut writer) = AsyncReadExt::split(stream);
         let responses = Mutex::new(HashMap::<u32, mesh::OneshotSender<mesh::Message>>::new());
         let recv_task = async {
             while let Some(message) = read_message(&mut reader)
@@ -96,7 +421,17 @@ impl Client {
 
         let send_task = async {
             let mut next_stream_id = 1;
-            while let Ok(request) = rpc_recv.recv().await {
+            loop {
+                let request = if let Some(req) = self.waiting.pop_front() {
+                    Some(req)
+                } else if let Some(recv) = &mut self.rpc_recv {
+                    recv.next().await
+                } else {
+                    None
+                };
+                let Some(request) = request else {
+                    break;
+                };
                 responses
                     .lock()
                     .insert(next_stream_id, request.rpc.port.into());
@@ -105,7 +440,9 @@ impl Client {
                     service: request.service,
                     method: request.rpc.method,
                     payload: request.rpc.data,
-                    timeout_nano: request.timeout.unwrap_or(0),
+                    timeout_nano: request.deadline.map_or(0, |deadline| {
+                        (*deadline - Deadline::now()).as_nanos() as u64
+                    }),
                     metadata: vec![],
                 });
 
@@ -119,51 +456,6 @@ impl Client {
         };
 
         (send_task, recv_task).race().await
-    }
-
-    /// Sends an RPC message to the server.
-    fn send<T: ServiceRpc>(&self, rpc: T, timeout: Option<Duration>) {
-        self.send.send(mesh::Message::new(ClientRequest {
-            service: T::NAME.to_string(),
-            timeout: timeout.map(|d| d.as_nanos() as u64),
-            rpc,
-        }));
-    }
-
-    /// Calls a remote function `rpc` with `input` and with no timeout, and
-    /// waits for a result.
-    pub async fn call<F, R, T, U>(&self, rpc: F, input: T) -> anyhow::Result<Result<U, Status>>
-    where
-        F: FnOnce(T, mesh::OneshotSender<Result<U, Status>>) -> R,
-        R: ServiceRpc,
-        U: MeshPayload,
-    {
-        self.start_call(rpc, input, None).await.context("rpc error")
-    }
-
-    /// Calls a remote function `rpc` with `input` and returns a mesh channel
-    /// that will receive the result.
-    pub fn start_call<F, R, T, U>(
-        &self,
-        rpc: F,
-        input: T,
-        timeout: Option<Duration>,
-    ) -> mesh::OneshotReceiver<Result<U, Status>>
-    where
-        F: FnOnce(T, mesh::OneshotSender<Result<U, Status>>) -> R,
-        R: ServiceRpc,
-        U: MeshPayload,
-    {
-        let (send, recv) = mesh::oneshot();
-
-        self.send(rpc(input, send), timeout);
-        recv
-    }
-
-    /// Shuts down the client, waiting for the associated task to complete.
-    pub async fn shutdown(self) {
-        drop(self.send);
-        self.task.await;
     }
 }
 

--- a/support/mesh/mesh_rpc/src/lib.rs
+++ b/support/mesh/mesh_rpc/src/lib.rs
@@ -16,7 +16,7 @@
 #[cfg(test)]
 extern crate self as mesh_rpc;
 
-mod client;
+pub mod client;
 mod message;
 mod rpc;
 mod server;

--- a/support/mesh/mesh_rpc/src/server.rs
+++ b/support/mesh/mesh_rpc/src/server.rs
@@ -554,10 +554,12 @@ mod grpc {
 
 #[cfg(test)]
 mod tests {
+    use crate::client::ExistingConnection;
     use crate::Client;
     use crate::Server;
     use futures::executor::block_on;
     use pal_async::local::block_with_io;
+    use pal_async::socket::PolledSocket;
     use pal_async::DefaultPool;
     use test_with_tracing::test;
 
@@ -577,9 +579,13 @@ mod tests {
 
         let client_thread = std::thread::spawn(move || {
             DefaultPool::run_with(|driver| async move {
-                let client = Client::new(&driver, c);
+                let client = Client::new(
+                    &driver,
+                    ExistingConnection::new(PolledSocket::new(&driver, c).unwrap()),
+                );
                 let response = client
-                    .call(
+                    .call()
+                    .start(
                         items::Example::Method1,
                         items::Method1Request {
                             foo: "abc".to_string(),
@@ -587,7 +593,6 @@ mod tests {
                         },
                     )
                     .await
-                    .unwrap()
                     .unwrap();
 
                 assert_eq!(&response.foo, "abc123");

--- a/support/mesh/src/lib.rs
+++ b/support/mesh/src/lib.rs
@@ -17,6 +17,7 @@ pub use mesh_channel::cancel::Cancel;
 pub use mesh_channel::cancel::CancelContext;
 pub use mesh_channel::cancel::CancelReason;
 pub use mesh_channel::cancel::Cancelled;
+pub use mesh_channel::cancel::Deadline;
 pub use mesh_channel::cell::cell;
 pub use mesh_channel::cell::Cell;
 pub use mesh_channel::cell::CellUpdater;


### PR DESCRIPTION
Add kmsg output options for seeing paravisor logs in real time.

Also move existing paravisor commands (including paravisor modes for `inspect` and `start`) under a new `paravisor` subcommand (alias `pv`). This is just as short as using `-p`, and it's easier to understand and extend.